### PR TITLE
Alternative for doing nested specs

### DIFF
--- a/src/main/kotlin/com/uchuhimo/konf/Spec.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/Spec.kt
@@ -160,8 +160,11 @@ interface Spec {
      * @param prefix inner spec prefix
      * @return nested spec with the specified prefix
      */
-    fun nestedSpec(prefix: String): Spec {
-        return ConfigSpec(prefix).also(this::addInnerSpec)
+    fun nestedSpec(prefix: String? = null): ReadOnlyProperty<Any?, Spec> {
+        return object : ReadOnlyProperty<Any?, Spec> {
+            override fun getValue(thisRef: Any?, property: KProperty<*>): Spec =
+                    ConfigSpec(prefix ?: property.name).also(this@Spec::addInnerSpec)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/uchuhimo/konf/Spec.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/Spec.kt
@@ -154,6 +154,16 @@ interface Spec {
         }
     }
 
+    /**
+     * Creates a nested spec with the specified prefix.
+     *
+     * @param prefix inner spec prefix
+     * @return nested spec with the specified prefix
+     */
+    fun nestedSpec(prefix: String): Spec {
+        return ConfigSpec(prefix).also(this::addInnerSpec)
+    }
+
     companion object {
         /**
          * A dummy implementation for [Spec].

--- a/src/main/kotlin/com/uchuhimo/konf/Spec.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/Spec.kt
@@ -160,12 +160,7 @@ interface Spec {
      * @param prefix inner spec prefix
      * @return nested spec with the specified prefix
      */
-    fun nestedSpec(prefix: String? = null): ReadOnlyProperty<Any?, Spec> {
-        return object : ReadOnlyProperty<Any?, Spec> {
-            override fun getValue(thisRef: Any?, property: KProperty<*>): Spec =
-                    ConfigSpec(prefix ?: property.name).also(this@Spec::addInnerSpec)
-        }
-    }
+    fun nestedSpec(prefix: String? = null) = NestedSpecProperty(this, prefix)
 
     companion object {
         /**
@@ -282,6 +277,19 @@ open class LazyProperty<T>(
             ?: property.name, thunk, description, type, nullable) {}
         return object : ReadOnlyProperty<Any?, LazyItem<T>> {
             override fun getValue(thisRef: Any?, property: KProperty<*>): LazyItem<T> = item
+        }
+    }
+}
+
+class NestedSpecProperty(
+        val spec: Spec,
+        val prefix: String?
+) {
+    operator fun provideDelegate(thisRef: Any?, property: KProperty<*>): ReadOnlyProperty<Any?, Spec> {
+        val spec = ConfigSpec(prefix ?: property.name).also(spec::addInnerSpec)
+
+        return object : ReadOnlyProperty<Any?, Spec> {
+            override fun getValue(thisRef: Any?, property: KProperty<*>) = spec
         }
     }
 }

--- a/src/test/kotlin/com/uchuhimo/konf/ConfigSpecSpek.kt
+++ b/src/test/kotlin/com/uchuhimo/konf/ConfigSpecSpek.kt
@@ -163,6 +163,13 @@ object ConfigSpecSpek : Spek({
                     assertThat(spec["a.bb.inner2"].items, isEmpty)
                     assertThat(spec["a.bb.inner2"].innerSpecs.size, equalTo(1))
                     assertThat(spec["a.bb.inner2"].innerSpecs.toList()[0].prefix, equalTo("level2"))
+
+                    // TODO: Help wanted to make these test (issue on GitHub)
+                    assertThat(spec["a.bb.nested"].items.size, equalTo(1))
+                    assertThat(spec["a.bb.nested"].innerSpecs.size, equalTo(1))
+                    assertThat(spec["a.bb.nested"].innerSpecs.toList()[0].prefix, equalTo("nested2"))
+                    assertThat(spec["a.bb.nested.nested2"].items, isEmpty)
+                    assertThat(spec["a.bb.nested.nested2"].innerSpecs, isEmpty)
                 }
             }
             on("get an invalid path") {
@@ -282,6 +289,11 @@ object ConfigSpecSpek : Spek({
 
 object Nested : ConfigSpec("a.bb") {
     val item by required<Int>("int", "description")
+
+    val nested by nestedSpec()
+    val nestedItem by nested.required<Int>()
+
+    val nested2 by nested.nestedSpec()
 
     object Inner : ConfigSpec() {
         val item by required<Int>()


### PR DESCRIPTION
This PR adds a new small utility function that makes it easy to do nested specs, without creating new objects. The motivation for this is to provide a more succinct syntax when creating nested spec, and accessing properties without chaining classes together.

### Example
Old syntax:
```kotlin
object Service : ConfigSpec() {
    val name by optional("test")

    object Backend : ConfigSpec() {
        val host by optional("127.0.0.1")
        val port by optional(7777)

        object Login : ConfigSpec() {
            val user by optional("admin")
            val password by optional("123456")
        }
    }
}

// config[Service.name]
// config[Service.Backend.host]
// config[Service.Backend.Login.user]
```
New syntax:
```kotlin
object Service : ConfigSpec() {
    val name by optional("test")

    val backend by nestedSpec()
    val host by backend.optional("127.0.0.1")
    val port by backend.optional(7777)

    val login by backend.nestedSpec()
    val user by login.optional("admin")
    val password by login.optional("123456")
}

// config[Service.name]
// config[Service.host]
// config[Service.user]
```

Related issue: #14 
Failing tests related: #21 

## Checklist
- [x] Document new function
- [ ] Add tests for the new function
- [ ] Update README documentation