### PR TITLE
[BUGFIX] ParseException with single element lists or empty lists

### DIFF
--- a/src/main/kotlin/com/uchuhimo/konf/source/base/StringValueSource.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/source/base/StringValueSource.kt
@@ -51,10 +51,10 @@ interface StringValueSource : Source, SourceInfo {
 
     override fun toList(): List<Source> {
         val value = getValue()
-        if (value.isNotEmpty()) {
-            return value.split(',').map { SingleStringValueSource(it, context = context) }
+        return if (value.isEmpty()) {
+            listOf()
         } else {
-            throw ParseException("$value cannot be parsed to a list")
+            value.split(',').map { SingleStringValueSource(it, context = context) }
         }
     }
 

--- a/src/main/kotlin/com/uchuhimo/konf/source/base/StringValueSource.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/source/base/StringValueSource.kt
@@ -51,7 +51,7 @@ interface StringValueSource : Source, SourceInfo {
 
     override fun toList(): List<Source> {
         val value = getValue()
-        if (value.isNotEmpty() && value.contains(',')) {
+        if (value.isNotEmpty()) {
             return value.split(',').map { SingleStringValueSource(it, context = context) }
         } else {
             throw ParseException("$value cannot be parsed to a list")

--- a/src/test/kotlin/com/uchuhimo/konf/source/base/FlatSourceSpec.kt
+++ b/src/test/kotlin/com/uchuhimo/konf/source/base/FlatSourceSpec.kt
@@ -112,6 +112,25 @@ object FlatSourceSpec : SubjectSpek<FlatSource>({
         }
     }
 
+    given("a config that contains a required list of strings") {
+        val parameterName = "flatsourcespeclist"
+        val spec = object : ConfigSpec() {
+            val list by required<List<String>>(name = parameterName)
+        }
+        fun configFromSystemProperties() = Config {
+            addSpec(spec)
+        }.from.systemProperties()
+        it("should work with a single element") {
+            System.setProperty(parameterName, "a")
+            assertThat(configFromSystemProperties()[spec.list], equalTo(listOf("a")))
+            System.clearProperty(parameterName)
+        }
+        it("should work with multiple elements") {
+            System.setProperty(parameterName, "a,b")
+            assertThat(configFromSystemProperties()[spec.list], equalTo(listOf("a", "b")))
+            System.clearProperty(parameterName)
+        }
+    }
     given("a config that contains list of strings with commas") {
         val spec = object : ConfigSpec() {
             @Suppress("unused")

--- a/src/test/kotlin/com/uchuhimo/konf/source/base/FlatSourceSpec.kt
+++ b/src/test/kotlin/com/uchuhimo/konf/source/base/FlatSourceSpec.kt
@@ -120,6 +120,11 @@ object FlatSourceSpec : SubjectSpek<FlatSource>({
         fun configFromSystemProperties() = Config {
             addSpec(spec)
         }.from.systemProperties()
+        it("should work with an empty list") {
+            System.setProperty(parameterName, "")
+            assertThat(configFromSystemProperties()[spec.list], equalTo(listOf()))
+            System.clearProperty(parameterName)
+        }
         it("should work with a single element") {
             System.setProperty(parameterName, "a")
             assertThat(configFromSystemProperties()[spec.list], equalTo(listOf("a")))


### PR DESCRIPTION
# Problem

Parsing list configuration property which contains only a single element or no elements.

## Expected Behaviour

Parsing the config property returns a single element list or an empty list.

## Actual Behaviour

```
com.uchuhimo.konf.source.LoadException: fail to load flatsourcespeclist
Caused by: com.uchuhimo.konf.source.ParseException: flatsourcespeclist in {...} cannot be parsed to a list
	at com.uchuhimo.konf.source.base.FlatSource.toList(FlatSource.kt:97)
	at com.uchuhimo.konf.source.SourceKt.toListValue(Source.kt:911)
	at com.uchuhimo.konf.source.SourceKt.toValue(Source.kt:884)
	at com.uchuhimo.konf.source.SourceKt.loadItem(Source.kt:741)
	... 45 more
```

# Change

I attempted to fix it by removing the check that every list *must* contain a separator (`,`) and must not be empty but I'm not sure what will be the impact of this as `isList()` also uses the same logic. Can you give an indication whether I fixed it correctly like this?

I was also not sure whether I put the test at the correct place.

Thanks!