### PR TITLE
Remove dependency on kotlinx-bimap.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,6 @@ fun DependenciesHandler.dependencySet(group: String, version: String, action: De
 
 configure<DependencyManagementExtension> {
     dependencies {
-        dependency("com.uchuhimo:kotlinx-bimap:${Versions.bimap}")
         dependency("org.apiguardian:apiguardian-api:${Versions.apiguardian}")
         dependency("com.typesafe:config:${Versions.hocon}")
         dependency("org.yaml:snakeyaml:${Versions.yaml}")
@@ -117,7 +116,6 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.apiguardian:apiguardian-api")
-    implementation("com.uchuhimo:kotlinx-bimap")
     implementation("com.typesafe:config")
     implementation("org.yaml:snakeyaml")
     implementation("com.moandjiezana.toml:toml4j")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,6 @@ object Versions {
     val dependencyUpdate = "0.21.0"
     // don't upgrade to 0.9.18
     val dokka = "0.9.17"
-    val bimap = "1.2"
     val apiguardian = "1.0.0"
     val hocon = "1.3.3"
     val yaml = "1.24"

--- a/src/main/kotlin/com/uchuhimo/konf/BaseConfig.kt
+++ b/src/main/kotlin/com/uchuhimo/konf/BaseConfig.kt
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.uchuhimo.collections.mutableBiMapOf
 import com.uchuhimo.konf.source.Source
 import com.uchuhimo.konf.source.deserializer.DurationDeserializer
 import com.uchuhimo.konf.source.deserializer.EmptyStringToCollectionDeserializerModifier
@@ -54,7 +53,7 @@ open class BaseConfig(
     protected val specsInLayer = mutableListOf<Spec>()
     protected val sourcesInLayer = ArrayDeque<Source>()
     protected val valueByItem = mutableMapOf<Item<*>, ValueState>()
-    protected val nameByItem = mutableBiMapOf<Item<*>, String>()
+    protected val nameByItem = mutableMapOf<Item<*>, String>()
     protected val featuresInLayer = mutableMapOf<Feature, Boolean>()
 
     private var hasChildren = false
@@ -183,7 +182,7 @@ open class BaseConfig(
         return item ?: parent?.getItemOrNull(name)
     }
 
-    protected fun getItemInLayerOrNull(name: String) = lock.read { nameByItem.inverse[name] }
+    protected fun getItemInLayerOrNull(name: String) = lock.read { nameByItem.entries.singleOrNull { it.value == name }?.key }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T> getOrNull(name: String): T? = getOrNull(name, errorWhenNotFound = false) as T?


### PR DESCRIPTION
This was done to remove transitive dependency on Guava (goal of #19). 

Since map inversion was used only in one place, I replaced it with `singleOrNull` lookup.

I'm not sure if I should add guard against adding `name` which is already in the map here:

```java
nameByItem[item] = name
```
