### PR TITLE
upgrade snakeyaml to 2.0

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val spotless = "5.11.1"
     const val taskTree = "1.5"
     const val toml4j = "0.7.2"
-    const val yaml = "1.28"
+    const val yaml = "2.0"
 
     // Since 1.8, the minimum supported runtime version is JDK 11.
     const val googleJavaFormat = "1.7"

--- a/konf-yaml/src/main/kotlin/com/uchuhimo/konf/source/yaml/YamlProvider.kt
+++ b/konf-yaml/src/main/kotlin/com/uchuhimo/konf/source/yaml/YamlProvider.kt
@@ -21,6 +21,7 @@ import com.uchuhimo.konf.source.Provider
 import com.uchuhimo.konf.source.RegisterExtension
 import com.uchuhimo.konf.source.Source
 import com.uchuhimo.konf.source.asSource
+import org.yaml.snakeyaml.LoaderOptions
 import org.yaml.snakeyaml.Yaml
 import org.yaml.snakeyaml.constructor.AbstractConstruct
 import org.yaml.snakeyaml.constructor.SafeConstructor
@@ -60,7 +61,7 @@ object YamlProvider : Provider {
     fun get() = this
 }
 
-private class YamlConstructor : SafeConstructor() {
+private class YamlConstructor : SafeConstructor(LoaderOptions()) {
     init {
         yamlConstructors[Tag.NULL] = object : AbstractConstruct() {
             override fun construct(node: Node?): Any? {


### PR DESCRIPTION
Fixes snakeyaml compatibility with the 2.0 release. While konf is most likely "safe" from the CVE, Snakeyaml 2.0 isn't fully backwards compatible and this prevents upgrades to Jackson 2.15 (which uses Snakeyaml 2.0, etc).